### PR TITLE
Build and dist darwin-arm64 artifacts

### DIFF
--- a/changelog/@unreleased/pr-47.v2.yml
+++ b/changelog/@unreleased/pr-47.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adds darwin-arm64 as a target for build and dist
+  links:
+  - https://github.com/palantir/godel-mod-plugin/pull/47

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -8,6 +8,8 @@ products:
       os-archs:
       - os: darwin
         arch: amd64
+      - os: darwin
+        arch: arm64
       - os: linux
         arch: amd64
     dist:
@@ -18,6 +20,8 @@ products:
             os-archs:
             - os: darwin
               arch: amd64
+            - os: darwin
+              arch: arm64
             - os: linux
               arch: amd64
     publish: {}


### PR DESCRIPTION
## Before this PR
Currently, this plugin does not publish any artifacts for darwin-arm64, which means that the plugin cannot run on machines that use that OS/Arch combination (M1 macs).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds darwin-arm64 as a target for build and dist
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

